### PR TITLE
update gapps link

### DIFF
--- a/app.js
+++ b/app.js
@@ -161,7 +161,7 @@ function refresh() {
                     entry.addons = [
                         {
                             "name": "Google Apps",
-                            "url": "http://download2.clockworkmod.com/gapps/gapps-ics-20120224-signed.zip"
+                            "url": "http://download2.clockworkmod.com/gapps/gapps-ics-20120304-signed.zip"
                         }
                     ]
                   }


### PR DESCRIPTION
The old version gives an AccessDenied error.
